### PR TITLE
Adding Template.from_json(), documentation and typo fix

### DIFF
--- a/collection_json.py
+++ b/collection_json.py
@@ -144,7 +144,8 @@ class Template(ComparableObject):
     def from_json(data):
         """Return a template instance.
 
-        Convenience method for parsing 'write' responses which should only contain a template object.
+        Convenience method for parsing 'write' responses,
+        which should only contain a template object.
 
         This method parses a json string into a Template object.
 

--- a/collection_json.py
+++ b/collection_json.py
@@ -270,7 +270,7 @@ class Item(ComparableObject):
 
     @property
     def properties(self):
-        """Return a list of names that can be looked up on the template."""
+        """Return a list of names that can be looked up on the item."""
         return [item.name for item in self.data]
 
     def to_dict(self):

--- a/collection_json.py
+++ b/collection_json.py
@@ -144,8 +144,7 @@ class Template(ComparableObject):
     def from_json(data):
         """Return a template instance.
 
-        Convenience method for parsing 'write' responses which should only contain the template,
-        not in a collection object.
+        Convenience method for parsing 'write' responses which should only contain a template object.
 
         This method parses a json string into a Template object.
 

--- a/collection_json.py
+++ b/collection_json.py
@@ -140,6 +140,29 @@ class Template(ComparableObject):
 
     """Object representing a Collection+JSON template object."""
 
+    @staticmethod
+    def from_json(data):
+        """Return a template instance.
+
+        Convenience method for parsing 'write' responses which should only contain the template,
+        not in a collection object.
+
+        This method parses a json string into a Template object.
+
+        Raises `ValueError` when no valid document is provided.
+
+        """
+        try:
+            data = json.loads(data)
+            kwargs = data.get('template')
+            if not kwargs:
+                raise ValueError
+        except ValueError:
+            raise ValueError('Not valid Collection+JSON template data.')
+
+        template = Template(**kwargs)
+        return template
+
     def __init__(self, data=None):
         if data is None:
             data = []

--- a/docs/examples.txt
+++ b/docs/examples.txt
@@ -108,3 +108,16 @@ Inspecting items in a collection
      'first_name'
      >>> collection.items[0].data[0].value
      'John'
+
+Serializing a template from json
+
+.. code-block:: python
+
+    >>> from collection_json import Template
+    >>> data = '{"template": {"data": [ {"name": "first_name", "value": "John"}, {"name": "last_name", "value": "Doe}'
+    >>> template = Template.from_json(data)
+    >>> template.first_name.value
+    'John'
+    >>> template.last_name.value
+    'Doe'
+

--- a/tests.py
+++ b/tests.py
@@ -477,9 +477,8 @@ class TemplateTestCase(TestCase):
             }
         }
         data = json.dumps(expected)
-        with self.assertRaisesRegexp(ValueError, "Not valid Collection\+JSON template data."):
-            template = Template.from_json(data)
-            self.assertFalse(template)
+        with self.assertRaises(ValueError):
+            Template.from_json(data)
 
 
 class ItemTestCase(TestCase):

--- a/tests.py
+++ b/tests.py
@@ -452,6 +452,35 @@ class TemplateTestCase(TestCase):
         template = Template([data])
         self.assertEqual(template.name, data)
 
+    def test_template_from_json_no_error(self):
+        expected = {
+            'template': {
+                'data': [
+                    {'name': 'name', 'value': 'value'},
+                    {'name': 'name1', 'value': 'value1'},
+                ]
+            }
+        }
+        data = json.dumps(expected)
+        template = Template.from_json(data)
+        self.assertEqual(template.to_dict(), expected)
+
+    def test_template_from_json_collection(self):
+        expected = {
+            'collection': {
+                'template': {
+                    'data': [
+                        {'name': 'name', 'value': 'value'},
+                        {'name': 'name1', 'value': 'value1'},
+                    ]
+                }
+            }
+        }
+        data = json.dumps(expected)
+        with self.assertRaisesRegexp(ValueError, "Not valid Collection\+JSON template data."):
+            template = Template.from_json(data)
+            self.assertFalse(template)
+
 
 class ItemTestCase(TestCase):
     def test_item_minimal(self):


### PR DESCRIPTION
I noticed that the examples say that clients should send requests to the server in template form only. So I added support and unit tests for a staticmethod to support from_json on Templates, the recommended way to parse data.

http://amundsen.com/media-types/collection/examples/#ex-template
7.
Write Representation

When sending data to the server, clients should fill in the template object and use that as the body of an HTTP POST (for "create") or HTTP PUT ("update") request. See Reading and Writing Data for more details.

{ "template" : {
    "data" : [
      {"name" : "full-name", "value" : "W. Chandry"},
      {"name" : "email", "value" : "wchandry@example.org"},
      {"name" : "blog", "value" : "http://example.org/blogs/wchandry"},
      {"name" : "avatar", "value" : "http://example.org/images/wchandry"}
    ]
  }
}

Note that only the template object SHOULD be sent (it does not need to be wrapped in a collection object) and that the only properties needed for each data element are the name and value properties