### PR TITLE
Collection, Template, Item and Query iterable ceorcision and type checking

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ collection_json.egg-info/
 dist/
 .coverage
 docs/_build/
+.DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,3 @@ collection_json.egg-info/
 dist/
 .coverage
 docs/_build/
-.DS_Store

--- a/collection_json.py
+++ b/collection_json.py
@@ -18,15 +18,15 @@ class ArrayProperty(object):
         """
         self.cls = cls
         self.name = name
-        self.value = None
+        self.value_attr = "_" + name
 
-    def __get__(self, value, type=None):
-        return self.value
+    def __get__(self, instance, owner):
+        return getattr(instance, self.value_attr, None)
 
-    def __set__(self, obj, value):
+    def __set__(self, instance, value):
         if value is None:
             value = []
-        self.value = Array(self.cls, self.name, value)
+        setattr(instance, self.value_attr, Array(self.cls, self.name, value))
 
 
 class TypedProperty(object):
@@ -37,22 +37,22 @@ class TypedProperty(object):
 
     """
 
-    def __init__(self, cls):
+    def __init__(self, cls, name):
         """Constructs the typed property
 
         :param cls type: the type of object expected
         """
         self.cls = cls
-        self.value = None
+        self.value_attr = "_" + name
 
-    def __get__(self, value, type=None):
-        return self.value
+    def __get__(self, instance, owner):
+        return getattr(instance, self.value_attr, None)
 
-    def __set__(self, obj, value):
+    def __set__(self, instance, value):
         if value is None or isinstance(value, self.cls):
-            self.value = value
+            setattr(instance, self.value_attr, value)
         elif isinstance(value, dict):
-            self.value = self.cls(**value)
+            setattr(instance, self.value_attr, self.cls(**value))
         else:
             raise TypeError("Invalid value '%s', "
                             "expected dict or '%s'" % (value,
@@ -386,8 +386,8 @@ class Collection(ComparableObject):
 
     """Object representing a Collection+JSON document."""
 
-    error = TypedProperty(Error)
-    template = TypedProperty(Template)
+    error = TypedProperty(Error, "error")
+    template = TypedProperty(Template, "template")
     items = ArrayProperty(Item, "items")
     links = ArrayProperty(Link, "links")
     queries = ArrayProperty(Query, "queries")

--- a/collection_json.py
+++ b/collection_json.py
@@ -7,7 +7,15 @@ __version__ = '0.1.0'
 
 
 class ArrayProperty(object):
+
+    """Property which converts from any enumerable to a typed Array instance."""
+
     def __init__(self, cls, name):
+        """Constructs typed array property
+
+        :param cls type: the type of objects expected in the array
+        :param name str: name of the property
+        """
         self.cls = cls
         self.name = name
         self.value = None
@@ -22,7 +30,18 @@ class ArrayProperty(object):
 
 
 class TypedProperty(object):
+
+    """Property which is assignable only to a specific type of instance.
+
+    Additionally supports assigning a dictionary convertable to the type.
+
+    """
+
     def __init__(self, cls):
+        """Constructs the typed property
+
+        :param cls type: the type of object expected
+        """
         self.cls = cls
         self.value = None
 

--- a/collection_json.py
+++ b/collection_json.py
@@ -8,7 +8,7 @@ __version__ = '0.1.0'
 
 class ArrayProperty(object):
 
-    """Property which converts from any enumerable to a typed Array instance."""
+    """A descriptor that converts from any enumerable to a typed Array."""
 
     def __init__(self, cls, name):
         """Constructs typed array property
@@ -18,20 +18,21 @@ class ArrayProperty(object):
         """
         self.cls = cls
         self.name = name
-        self.value_attr = "_" + name
 
     def __get__(self, instance, owner):
-        return getattr(instance, self.value_attr, None)
+        if self.name in instance.__dict__:
+            return instance.__dict__[self.name]
+        raise AttributeError
 
     def __set__(self, instance, value):
         if value is None:
             value = []
-        setattr(instance, self.value_attr, Array(self.cls, self.name, value))
+        instance.__dict__[self.name] = Array(self.cls, self.name, value)
 
 
 class TypedProperty(object):
 
-    """Property which is assignable only to a specific type of instance.
+    """A descriptor for assigning only a specific type of instance.
 
     Additionally supports assigning a dictionary convertable to the type.
 
@@ -43,16 +44,18 @@ class TypedProperty(object):
         :param cls type: the type of object expected
         """
         self.cls = cls
-        self.value_attr = "_" + name
+        self.name = name
 
     def __get__(self, instance, owner):
-        return getattr(instance, self.value_attr, None)
+        if self.name in instance.__dict__:
+            return instance.__dict__[self.name]
+        raise AttributeError
 
     def __set__(self, instance, value):
         if value is None or isinstance(value, self.cls):
-            setattr(instance, self.value_attr, value)
+            instance.__dict__[self.name] = value
         elif isinstance(value, dict):
-            setattr(instance, self.value_attr, self.cls(**value))
+            instance.__dict__[self.name] = self.cls(**value)
         else:
             raise TypeError("Invalid value '%s', "
                             "expected dict or '%s'" % (value,

--- a/tests.py
+++ b/tests.py
@@ -975,6 +975,11 @@ class ArrayPropertyTestCase(TestCase):
         s2.aprop = [1, 2]
         self.assertNotEqual(s1.aprop, s2.aprop)
 
+    def test_attribute_error(self):
+        s1 = ArrayPropertyTestCase.Simple()
+        with self.assertRaises(AttributeError):
+            s1.aprop
+
 
 class TypedPropertyTestCase(TestCase):
 
@@ -984,6 +989,11 @@ class TypedPropertyTestCase(TestCase):
     def test_instance_independence(self):
         s1 = TypedPropertyTestCase.Simple()
         s2 = TypedPropertyTestCase.Simple()
-        s1.aprop = 1
-        s2.aprop = 2
-        self.assertNotEqual(s1.aprop, s2.aprop)
+        s1.tprop = 1
+        s2.tprop = 2
+        self.assertNotEqual(s1.tprop, s2.tprop)
+
+    def test_attribute_error(self):
+        s1 = TypedPropertyTestCase.Simple()
+        with self.assertRaises(AttributeError):
+            s1.tprop

--- a/tests.py
+++ b/tests.py
@@ -325,6 +325,44 @@ class CollectionTestCase(TestCase):
         expected = json.dumps(collection.to_dict())
         self.assertEqual(str(collection), expected)
 
+    def test_property_invalid_assignment(self):
+        collection = Collection('href')
+        invalid_obj = object()
+        with self.assertRaises(TypeError):
+            collection.error = invalid_obj
+
+        with self.assertRaises(TypeError):
+            collection.template = invalid_obj
+
+        with self.assertRaises(TypeError):
+            collection.items = invalid_obj
+
+        with self.assertRaises(TypeError):
+            collection.links = invalid_obj
+
+        with self.assertRaises(TypeError):
+            collection.queries = invalid_obj
+
+    def test_array_property_conversion(self):
+        collection = Collection('href')
+        self.assertIsInstance(collection.items, Array)
+        self.assertIsInstance(collection.queries, Array)
+        self.assertIsInstance(collection.links, Array)
+
+        collection.items = []
+        self.assertIsInstance(collection.items, Array)
+        collection.queries = []
+        self.assertIsInstance(collection.queries, Array)
+        collection.links = []
+        self.assertIsInstance(collection.links, Array)
+
+        collection.items = None
+        self.assertIsInstance(collection.items, Array)
+        collection.queries = None
+        self.assertIsInstance(collection.queries, Array)
+        collection.links = None
+        self.assertIsInstance(collection.links, Array)
+
 
 class ErrorTestCase(TestCase):
 
@@ -480,6 +518,15 @@ class TemplateTestCase(TestCase):
         with self.assertRaises(ValueError):
             Template.from_json(data)
 
+    def test_array_property_conversion(self):
+        template = Template()
+        self.assertIsInstance(template.data, Array)
+        template.data = []
+        self.assertIsInstance(template.data, Array)
+        template.data = None
+        self.assertIsInstance(template.data, Array)
+        self.assertFalse(template.data)
+
 
 class ItemTestCase(TestCase):
     def test_item_minimal(self):
@@ -536,6 +583,21 @@ class ItemTestCase(TestCase):
         data = Data('name')
         item = Item(data=[data])
         self.assertEqual(item.name, data)
+
+    def test_array_property_conversion(self):
+        item = Item()
+        self.assertIsInstance(item.data, Array)
+        self.assertIsInstance(item.links, Array)
+        item.data = []
+        self.assertIsInstance(item.data, Array)
+        item.links = []
+        self.assertIsInstance(item.links, Array)
+        item.data = None
+        self.assertIsInstance(item.data, Array)
+        self.assertFalse(item.data)
+        item.links = None
+        self.assertIsInstance(item.links, Array)
+        self.assertFalse(item.links)
 
 
 class DataTestCase(TestCase):
@@ -637,6 +699,15 @@ class QueryTestCase(TestCase):
             ]
         }
         self.assertEqual(query.to_dict(), expected)
+
+    def test_array_property_conversion(self):
+        query = Query('href', 'rel')
+        self.assertIsInstance(query.data, Array)
+        query.data = []
+        self.assertIsInstance(query.data, Array)
+        query.data = None
+        self.assertIsInstance(query.data, Array)
+        self.assertFalse(query.data)
 
 
 class LinkTestCase(TestCase):

--- a/tests.py
+++ b/tests.py
@@ -325,46 +325,75 @@ class CollectionTestCase(TestCase):
         expected = json.dumps(collection.to_dict())
         self.assertEqual(str(collection), expected)
 
-    def test_property_invalid_assignment(self):
+    def test_set_error_invalid(self):
         collection = Collection('href')
         invalid_obj = object()
         with self.assertRaises(TypeError):
             collection.error = invalid_obj
 
+    def test_set_template_invalid(self):
+        collection = Collection('href')
+        invalid_obj = object()
         with self.assertRaises(TypeError):
             collection.template = invalid_obj
 
+    def test_set_items_invalid(self):
+        collection = Collection('href')
+        invalid_obj = object()
         with self.assertRaises(TypeError):
             collection.items = invalid_obj
 
+    def test_set_links_invalid(self):
+        collection = Collection('href')
+        invalid_obj = object()
         with self.assertRaises(TypeError):
             collection.links = invalid_obj
 
+    def test_set_queries_invalid(self):
+        collection = Collection('href')
+        invalid_obj = object()
         with self.assertRaises(TypeError):
             collection.queries = invalid_obj
 
-    def test_array_property_conversion(self):
+    def test_set_error(self):
+        error = Error()
+        expected = Collection('href', error=error)
         collection = Collection('href')
-        self.assertIsInstance(collection.items, Array)
-        self.assertIsInstance(collection.queries, Array)
-        self.assertIsInstance(collection.links, Array)
+        collection.error = error
+        self.assertIsInstance(collection.error, Error)
+        self.assertEqual(collection, expected)
 
-        collection.items = []
-        self.assertIsInstance(collection.items, Array)
-        collection.queries = []
-        self.assertIsInstance(collection.queries, Array)
-        collection.links = []
-        self.assertIsInstance(collection.links, Array)
+    def test_set_template(self):
+        template = Template()
+        expected = Collection('href', template=template)
+        collection = Collection('href')
+        collection.template = template
+        self.assertIsInstance(collection.template, Template)
+        self.assertEqual(collection, expected)
 
-        collection.items = None
+    def test_set_items(self):
+        item = Item()
+        expected = Collection('href', items=[item])
+        collection = Collection('href')
+        collection.items = [item]
         self.assertIsInstance(collection.items, Array)
-        self.assertFalse(collection.items)
-        collection.queries = None
-        self.assertIsInstance(collection.queries, Array)
-        self.assertFalse(collection.queries)
-        collection.links = None
+        self.assertEqual(collection, expected)
+
+    def test_set_links(self):
+        link = Link('href', 'rel')
+        expected = Collection('href', links=[link])
+        collection = Collection('href')
+        collection.links = [link]
         self.assertIsInstance(collection.links, Array)
-        self.assertFalse(collection.links)
+        self.assertEqual(collection, expected)
+
+    def test_set_queries(self):
+        query = Query('href', 'rel')
+        expected = Collection('href', queries=[query])
+        collection = Collection('href')
+        collection.queries = [query]
+        self.assertIsInstance(collection.queries, Array)
+        self.assertEqual(collection, expected)
 
 
 class ErrorTestCase(TestCase):
@@ -521,14 +550,19 @@ class TemplateTestCase(TestCase):
         with self.assertRaises(ValueError):
             Template.from_json(data)
 
-    def test_array_property_conversion(self):
+    def test_set_data_invalid(self):
         template = Template()
+        invalid_obj = object()
+        with self.assertRaises(TypeError):
+            template.data = invalid_obj
+
+    def test_set_data(self):
+        data = Data('name')
+        expected = Template(data=[data])
+        template = Template()
+        template.data = [data]
         self.assertIsInstance(template.data, Array)
-        template.data = []
-        self.assertIsInstance(template.data, Array)
-        template.data = None
-        self.assertIsInstance(template.data, Array)
-        self.assertFalse(template.data)
+        self.assertEqual(template, expected)
 
 
 class ItemTestCase(TestCase):
@@ -587,20 +621,33 @@ class ItemTestCase(TestCase):
         item = Item(data=[data])
         self.assertEqual(item.name, data)
 
-    def test_array_property_conversion(self):
+    def test_set_data_invalid(self):
         item = Item()
+        invalid_obj = object()
+        with self.assertRaises(TypeError):
+            item.data = invalid_obj
+
+    def test_set_links_invalid(self):
+        item = Item()
+        invalid_obj = object()
+        with self.assertRaises(TypeError):
+            item.links = invalid_obj
+
+    def test_set_data(self):
+        data = Data('name')
+        expected = Item(data=[data])
+        item = Item()
+        item.data = [data]
         self.assertIsInstance(item.data, Array)
+        self.assertEqual(item, expected)
+
+    def test_set_links(self):
+        link = Link('rel', 'href')
+        expected = Item(links=[link])
+        item = Item()
+        item.links = [link]
         self.assertIsInstance(item.links, Array)
-        item.data = []
-        self.assertIsInstance(item.data, Array)
-        item.links = []
-        self.assertIsInstance(item.links, Array)
-        item.data = None
-        self.assertIsInstance(item.data, Array)
-        self.assertFalse(item.data)
-        item.links = None
-        self.assertIsInstance(item.links, Array)
-        self.assertFalse(item.links)
+        self.assertEqual(item, expected)
 
 
 class DataTestCase(TestCase):
@@ -703,14 +750,19 @@ class QueryTestCase(TestCase):
         }
         self.assertEqual(query.to_dict(), expected)
 
-    def test_array_property_conversion(self):
+    def test_set_data_invalid(self):
         query = Query('href', 'rel')
+        invalid_obj = object()
+        with self.assertRaises(TypeError):
+            query.data = invalid_obj
+
+    def test_set_data(self):
+        data = Data('name')
+        expected = Query('href', 'rel', data=[data])
+        query = Query('href', 'rel')
+        query.data = [data]
         self.assertIsInstance(query.data, Array)
-        query.data = []
-        self.assertIsInstance(query.data, Array)
-        query.data = None
-        self.assertIsInstance(query.data, Array)
-        self.assertFalse(query.data)
+        self.assertEqual(query, expected)
 
 
 class LinkTestCase(TestCase):

--- a/tests.py
+++ b/tests.py
@@ -358,10 +358,13 @@ class CollectionTestCase(TestCase):
 
         collection.items = None
         self.assertIsInstance(collection.items, Array)
+        self.assertFalse(collection.items)
         collection.queries = None
         self.assertIsInstance(collection.queries, Array)
+        self.assertFalse(collection.queries)
         collection.links = None
         self.assertIsInstance(collection.links, Array)
+        self.assertFalse(collection.links)
 
 
 class ErrorTestCase(TestCase):

--- a/tests.py
+++ b/tests.py
@@ -4,6 +4,7 @@ from unittest import TestCase
 
 from collection_json import (
     Array,
+    ArrayProperty,
     Collection,
     Data,
     Error,
@@ -11,7 +12,6 @@ from collection_json import (
     Link,
     Query,
     Template,
-    ArrayProperty,
     TypedProperty
 )
 

--- a/tests.py
+++ b/tests.py
@@ -11,6 +11,8 @@ from collection_json import (
     Link,
     Query,
     Template,
+    ArrayProperty,
+    TypedProperty
 )
 
 
@@ -959,3 +961,29 @@ class ArrayTestCase(TestCase):
         bar = Link('href2', rel='baz', name='foo')
         links = Array(Link, 'links', [foo, bar])
         self.assertEqual(links.foo, [foo, bar])
+
+
+class ArrayPropertyTestCase(TestCase):
+
+    class Simple(object):
+        aprop = ArrayProperty(int, "aprop")
+
+    def test_instance_independence(self):
+        s1 = ArrayPropertyTestCase.Simple()
+        s2 = ArrayPropertyTestCase.Simple()
+        s1.aprop = [1, 2, 3]
+        s2.aprop = [1, 2]
+        self.assertNotEqual(s1.aprop, s2.aprop)
+
+
+class TypedPropertyTestCase(TestCase):
+
+    class Simple(object):
+        tprop = TypedProperty(int, "tprop")
+
+    def test_instance_independence(self):
+        s1 = TypedPropertyTestCase.Simple()
+        s2 = TypedPropertyTestCase.Simple()
+        s1.aprop = 1
+        s2.aprop = 2
+        self.assertNotEqual(s1.aprop, s2.aprop)

--- a/tests.py
+++ b/tests.py
@@ -365,11 +365,27 @@ class CollectionTestCase(TestCase):
         self.assertIsInstance(collection.error, Error)
         self.assertEqual(collection, expected)
 
+    def test_set_error_dict(self):
+        error = Error(code=1, title="title", message="message")
+        expected = Collection('href', error=error)
+        collection = Collection('href')
+        collection.error = error.to_dict()["error"]
+        self.assertIsInstance(collection.error, Error)
+        self.assertEqual(collection, expected)
+
     def test_set_template(self):
         template = Template()
         expected = Collection('href', template=template)
         collection = Collection('href')
         collection.template = template
+        self.assertIsInstance(collection.template, Template)
+        self.assertEqual(collection, expected)
+
+    def test_set_template_dict(self):
+        template = Template(data=[Data("name")])
+        expected = Collection('href', template=template)
+        collection = Collection('href')
+        collection.template = template.to_dict()["template"]
         self.assertIsInstance(collection.template, Template)
         self.assertEqual(collection, expected)
 


### PR DESCRIPTION
Ricardo,

I'd like to discuss the following changes to the interface and see if it is worthwhile.

A colleague of mine hit an issue. It was something along the following lines:

```
n = 10
col = Collection('href')
col.items = [Item() for i in range(n)]
col.to_dict()   # throws an attribute error
```

What is going on is that he unknowingly changed the items attribute from an *Array* to a *list*, which causes it to break later on the call to to_dict(). This may be a case of buyer beware, but I thought it would be nice to either make those attributes read-only or enforce the same assignment semantics as on construction. I implemented the latter in this pull request.

As a result you can now do the above and the list will be converted to an Array. Additionally, for those attributes which are sub-elements I also check to ensure they are either None, a dictionary or the type they are intended. Any other result throws a TypeError.

Please look it over when you get a chance -- and let me know what you think.

Dan